### PR TITLE
Update 8-fungsi-copy.go

### DIFF
--- a/chapter-A.15/8-fungsi-copy.go
+++ b/chapter-A.15/8-fungsi-copy.go
@@ -8,7 +8,7 @@ func main() {
 
 	var copiedElemen = copy(fruits, aFruits)
 
-	fmt.Println(fruits)       // ["apple", "watermelon", "pinnaple"]
+	fmt.Println(fruits)       // ["watermelon"]
 	fmt.Println(aFruits)      // ["watermelon", "pinnaple"]
 	fmt.Println(copiedElemen) // 1
 }


### PR DESCRIPTION
The builtin copy(dst, src) copies min(len(dst), len(src)) elements.

So if your dst is one, only one element will be copied.

https://golang.org/ref/spec#Appending_and_copying_slices
```
The number of elements copied is the minimum of len(src) and len(dst).
```