### PR TITLE
Pembaharuan A.13.7. fallthrough Dalam switch dan A.14.5. break & continue

### DIFF
--- a/A-perulangan.md
+++ b/A-perulangan.md
@@ -22,7 +22,7 @@ Perulangan di atas hanya akan berjalan ketika variabel `i` bernilai dibawah `5`,
 
 Cara ke-2 adalah dengan menuliskan kondisi setelah keyword `for` (hanya kondisi). Deklarasi dan iterasi variabel counter tidak dituliskan setelah keyword, hanya kondisi perulangan saja. Konsepnya mirip seperti `while` milik bahasa pemrograman lain.
 
-Kode berikut adalah contoh `for` dengan argumen hanya kondisi (seperti `if`), output yang dihasilkan sama seperti penerapan for cara pertama.
+Kode berikut adalah contoh `for` dengan argumen hanya kondisi (seperti `if`), output yang dihasilkan sama seperti penerapan `for` cara pertama.
 
 ```go
 var i = 0
@@ -60,7 +60,7 @@ Cara ke-4 adalah perulangan dengan menggunakan kombinasi keyword `for` dan `rang
 
 Keyword `break` digunakan untuk menghentikan secara paksa sebuah perulangan, sedangkan `continue` dipakai untuk memaksa maju ke perulangan berikutnya.
 
-Berikut merupakan contoh penerapan `continue` dan `break`. Kedua keyword tersebut dimanfaatkan untuk menampilkan angka genap berurutan yang lebih besar dari 0 dan dibawah 8.
+Berikut merupakan contoh penerapan `continue` dan `break`. Kedua keyword tersebut dimanfaatkan untuk menampilkan angka genap berurutan yang lebih besar dari 0 dan kurang dari atau sama dengan 8.
 
 ```go
 for i := 1; i <= 10; i++ {

--- a/A-seleksi-kondisi.md
+++ b/A-seleksi-kondisi.md
@@ -77,7 +77,7 @@ default:
 
 Pada kode di atas, tidak ada kondisi atau `case` yang terpenuhi karena nilai variabel `point` tetap `6`. Ketika hal seperti ini terjadi, blok kondisi `default` dipanggil. Bisa dibilang bahwa `default` merupakan `else` dalam sebuah switch.
 
-Perlu diketahui, switch pada pemrograman Go memiliki perbedaan dibanding bahasa lain. Di Go, ketika sebuah case terpenuhi, tidak akan dilanjutkan ke pengecekkan case selanjutnya, meskipun tidak ada keyword `break` di situ. Konsep ini berkebalikan dengan switch pada umumnya, yang ketika sebuah case terpenuhi, maka akan tetap dilanjut mengecek case selanjutnya kecuali ada keyword `break`.
+Perlu diketahui, switch pada pemrograman Go memiliki perbedaan dibanding bahasa lain. Di Go, ketika sebuah case terpenuhi, tidak akan dilanjutkan ke pengecekan case selanjutnya, meskipun tidak ada keyword `break` di situ. Konsep ini berkebalikan dengan switch pada umumnya, yang ketika sebuah case terpenuhi, maka akan tetap dilanjut mengecek case selanjutnya kecuali ada keyword `break`.
 
 ## A.13.4. Pemanfaatan `case` Untuk Banyak Kondisi
 
@@ -144,9 +144,9 @@ default:
 
 ## A.13.7. Penggunaan Keyword `fallthrough` Dalam `switch`
 
-Seperti yang sudah dijelaskan sebelumnya, bahwa switch pada Go memiliki perbedaan dengan bahasa lain. Ketika sebuah `case` terpenuhi, pengecekkan kondisi tidak akan diteruskan ke case-case setelahnya.
+Seperti yang sudah dijelaskan sebelumnya, bahwa switch pada Go memiliki perbedaan dengan bahasa lain. Ketika sebuah `case` terpenuhi, pengecekan kondisi tidak akan diteruskan ke case-case setelahnya.
 
-Keyword `fallthrough` digunakan untuk memaksa proses pengecekkan diteruskan ke `case` selanjutnya dengan **tanpa menghiraukan nilai kondisinya**, jadi case di pengecekan selanjutnya tersebut selalu dianggap benar (meskipun aslinya adalah salah).
+Keyword `fallthrough` digunakan untuk memaksa proses pengecekan diteruskan ke satu `case` selanjutnya dengan **tanpa menghiraukan nilai kondisinya**, jadi satu case di pengecekan selanjutnya tersebut selalu dianggap benar (meskipun aslinya adalah salah). Dalam sebuah `switch` lebih dari satu `fallthrough` bisa di tempatkan untuk memaksa melanjutkan proses pengecekan ke satu `case` setelahnya.
 
 ```go
 var point = 6
@@ -168,7 +168,7 @@ default:
 ```
 
 
-Setelah pengecekkan `case (point < 8) && (point > 3)` selesai, akan dilanjut ke pengecekkan `case point < 5`, karena ada `fallthrough` di situ.
+Setelah pengecekan `case (point < 8) && (point > 3)` selesai, akan dilanjut ke pengecekan `case point < 5`, karena ada `fallthrough` di situ.
 
 ![Penggunaan `fallthrough` dalam `switch`](images/A_seleksi_kondisi_2_fallthrough.png)
 


### PR DESCRIPTION
Commit : **Pembaharuan A.13.7. fallthrough Dalam switch**
- Menambahkan penjelasan bahwa `fallthrough` melanjutan pengejekan hanya ke satu `case` selanjutkan tanpa menghiraukan nilai kondisinya.
- Menambahkan penjelasan `fallthrough` bisa ditambahkan lebih dari satu untuk melanjutkan pengejekan ke satu `case` setelahnya.
- Memperbaiki imbuhan dari **pengecekkan** dengan akhiran -kan menjadi **pengecekan** dengan akhiran -an.

Commit : **Perbaharui kalimat penjelasan pada contoh di A.14.5.**
- Pembaruan kalimat pada contoh karena berbeda dengan hasil dari kode.
Diubah dari "menampilkan angka genap berurutan yang lebih besar dari 0 dan dibawah 8."
Menjadi "menampilkan angka genap berurutan yang lebih besar dari 0 dan kurang dari atau sama dengan 8"