### PR TITLE
fix: fixed typo on buffered channel

### DIFF
--- a/content/A-buffered-channel.md
+++ b/content/A-buffered-channel.md
@@ -57,7 +57,7 @@ Bisa dilihat output di atas, pada proses pengiriman data ke-4, diikuti dengan pr
 
 Pengiriman data indeks ke 0, 1, 2 dan 3 akan berjalan secara asynchronous, hal ini karena channel ditentukan nilai buffer-nya sebanyak 3 (ingat, jika nilai buffer adalah 3, maka 4 data yang akan di-buffer). Pengiriman selanjutnya (indeks 5) hanya akan terjadi jika ada salah satu data dari ke-empat data yang sebelumnya telah dikirimkan sudah diterima (dengan serah terima data yang bersifat blocking). Setelahnya, pengiriman data kembali dilakukan secara asynchronous (karena sudah ada slot buffer ada yang kosong).
 
-Karena pengiriman dan penerimaan data via buffered channel terjadi tidak selalu sycnrhonous (tergantung jumlah buffer-nya), maka ada kemungkinan dimana eksekusi program selesai namun tidak semua data diterima via channel `messages`. Karena alasan ini pada bagian akhir ditambahkan statement `time.Sleep(1 * time.Second)` agar ada jeda 1 detik sebelum program selesai.
+Karena pengiriman dan penerimaan data via buffered channel terjadi tidak selalu synchronous (tergantung jumlah buffer-nya), maka ada kemungkinan dimana eksekusi program selesai namun tidak semua data diterima via channel `messages`. Karena alasan ini pada bagian akhir ditambahkan statement `time.Sleep(1 * time.Second)` agar ada jeda 1 detik sebelum program selesai.
 
 #### • Fungsi `time.Sleep()`
 

--- a/content/CONTRIBUTING.md
+++ b/content/CONTRIBUTING.md
@@ -61,6 +61,7 @@ Berikut merupakan *hall of fame* kontributor yang sudah berbaik hati menyisihkan
 1. [MH Rohman Masyhar](https://github.com/rohmanhm)
 1. [Muhammad Faris 'Afif](https://github.com/muhfaris)
 1. [Muhammad Ridho](https://github.com/reedho)
+1. [Muhammad Zulfan Wahyudin](https://github.com/mzulfanw)
 1. [Mulia Nasution](https://github.com/mul14)
 1. [nekonako](https://github.com/nekonako)
 1. [Nuevo Querto](https://github.com/NuevoQuerto)


### PR DESCRIPTION
Fixed a typo in the chapter-32-buffered-channel/32.1-penerapan-buffered-channel.go file, changed 'sycnrhonous' to 'synchronous'