### PR TITLE
Fix incorrect function definition in example code

### DIFF
--- a/content/C-golang-redis.md
+++ b/content/C-golang-redis.md
@@ -66,7 +66,7 @@ Salah satu benefit yang didapat dengan menggunakan `go-redis` library, adalah su
 Ok, sekarang tambahkan kode berikut:
 
 ```go
-func () {
+func main() {
 	// ...
 	
 	key := "key-1"


### PR DESCRIPTION
Replaces an anonymous function with a proper 'main' function in the Go code example to ensure correct usage and clarity for readers.