### PR TITLE
docs: fix typo and improve Indonesian phrasing

### DIFF
--- a/content/A-fungsi-closure.md
+++ b/content/A-fungsi-closure.md
@@ -1,6 +1,6 @@
 # A.21. Fungsi Closure
 
-Definisi **Closure** adalah suatu *anonymous function* (atau fungsi tanpa nama) yang disimpan dalam variabel. Dengan adanya closure, kita bisa mendesain beberapa hal diantaranya seperti: membuat fungsi di dalam fungsi, atau bahkan membuat fungsi yang mengembalikan fungsi. Closure biasa dimanfaatkan untuk membungkus suatu proses yang hanya dijalankan sekali saja atau hanya dipakai pada blok tertentu saja.
+Definisi **Closure** adalah suatu *anonymous function* (atau fungsi tanpa nama) yang disimpan dalam variabel. Dengan adanya closure, kita bisa mendesain beberapa hal di antaranya: membuat fungsi di dalam fungsi, atau bahkan membuat fungsi yang mengembalikan fungsi. Closure biasa dimanfaatkan untuk membungkus suatu proses yang hanya dijalankan sekali saja atau hanya dipakai pada blok tertentu saja.
 
 ## A.21.1. Closure Disimpan Sebagai Variabel
 


### PR DESCRIPTION
- Change "diantaranya" to "di antaranya" (proper preposition)
- Remove redundant "seperti" after "di antaranya"