### PR TITLE
fix: rename min/max variable to prevent ambiguity with built-in functions

### DIFF
--- a/content/A-channel-select.md
+++ b/content/A-channel-select.md
@@ -29,13 +29,13 @@ func getAverage(numbers []int, ch chan float64) {
 }
 
 func getMax(numbers []int, ch chan int) {
-    var max = numbers[0]
+    var maxNum = numbers[0]
     for _, e := range numbers {
-        if max < e {
-            max = e
+        if maxNum < e {
+			maxNum = e
         }
     }
-    ch <- max
+    ch <- maxNum
 }
 ```
 
@@ -60,8 +60,8 @@ func main() {
         select {
         case avg := <-ch1:
             fmt.Printf("Avg \t: %.2f \n", avg)
-        case max := <-ch2:
-            fmt.Printf("Max \t: %d \n", max)
+        case maxNum := <-ch2:
+            fmt.Printf("Max \t: %d \n", maxNum)
         }
     }
 }
@@ -70,7 +70,7 @@ func main() {
 Pada kode di atas, pengiriman data pada channel `ch1` dan `ch2` dikontrol menggunakan `select`. Terdapat 2 buah `case` kondisi penerimaan data dari kedua channel tersebut.
 
  - Kondisi `case avg := <-ch1` akan terpenuhi ketika ada penerimaan data dari channel `ch1`, yang kemudian akan ditampung oleh variabel `avg`.
- - Kondisi `case max := <-ch2` akan terpenuhi ketika ada penerimaan data dari channel `ch2`, yang kemudian akan ditampung oleh variabel `max`.
+ - Kondisi `case maxNum := <-ch2` akan terpenuhi ketika ada penerimaan data dari channel `ch2`, yang kemudian akan ditampung oleh variabel `maxNum`.
 
 Karena ada 2 buah channel, maka perlu disiapkan perulangan 2 kali sebelum penggunaan keyword `select`.
 

--- a/content/A-fungsi-closure.md
+++ b/content/A-fungsi-closure.md
@@ -15,23 +15,23 @@ import "fmt"
 
 func main() {
     var getMinMax = func(n []int) (int, int) {
-        var min, max int
+        var minNum, maxNum int
         for i, e := range n {
             switch {
             case i == 0:
-                max, min = e, e
-            case e > max:
-                max = e
-            case e < min:
-                min = e
+                maxNum, minNum = e, e
+            case e > maxNum:
+                maxNum = e
+            case e < minNum:
+                minNum = e
             }
         }
-        return min, max
+        return minNum, maxNum
     }
 
     var numbers = []int{2, 3, 4, 3, 4, 2, 3}
-    var min, max = getMinMax(numbers)
-    fmt.Printf("data : %v\nmin  : %v\nmax  : %v\n", numbers, min, max)
+    var minNum, maxNum = getMinMax(numbers)
+    fmt.Printf("data : %v\nmin  : %v\nmax  : %v\n", numbers, minNum, maxNum)
 }
 ```
 
@@ -46,7 +46,7 @@ var getMinMax = func(n []int) (int, int) {
 Cara pemanggilan closure adalah dengan memperlakukan variabel closure seperti fungsi, dituliskan seperti pemanggilan fungsi.
 
 ```go
-var min, max = getMinMax(numbers)
+var minNum, maxNum = getMinMax(numbers)
 ```
 
 Output program:
@@ -62,7 +62,7 @@ Berikut merupakan penjelasan tambahan untuk beberapa hal dari kode yang sudah di
 Template `%v` digunakan untuk menampilkan data tanpa melihat tipe datanya. Jadi bisa digunakan untuk menampilkan data array, int, float, bool, dan lainnya. Bisa dilihat di contoh statement, data bertipe array dan numerik ditampilkan menggunakan `%v`.
 
 ```go
-fmt.Printf("data : %v\nmin  : %v\nmax  : %v\n", numbers, min, max)
+fmt.Printf("data : %v\nmin  : %v\nmax  : %v\n", numbers, minNum, maxNum)
 ```
 
 Template `%v` ini biasa dimanfaatkan untuk menampilkan sebuah data yang tipe nya bisa dinamis atau belum diketahui. Biasa digunakan untuk keperluan debugging, misalnya untuk menampilkan data bertipe `any` atau `interface{}`.
@@ -83,10 +83,10 @@ import "fmt"
 func main() {
     var numbers = []int{2, 3, 0, 4, 3, 2, 0, 4, 2, 0, 3}
 
-    var newNumbers = func(min int) []int {
+    var newNumbers = func(minNum int) []int {
         var r []int
         for _, e := range numbers {
-            if e < min {
+            if e < minNum {
                 continue
             }
             r = append(r, e)
@@ -106,7 +106,7 @@ Output program:
 Ciri khas dari penulisan IIFE adalah adanya tanda kurung parameter yang ditulis di akhir deklarasi closure. Jika IIFE memiliki parameter, maka argument-nya juga ditulis. Contoh:
 
 ```go
-var newNumbers = func(min int) []int {
+var newNumbers = func(minNum int) []int {
     // ...
 }(3)
 ```
@@ -124,10 +124,10 @@ package main
 
 import "fmt"
 
-func findMax(numbers []int, max int) (int, func() []int) {
+func findMax(numbers []int, maxNum int) (int, func() []int) {
     var res []int
     for _, e := range numbers {
-        if e <= max {
+        if e <= maxNum {
             res = append(res, e)
         }
     }
@@ -156,13 +156,13 @@ Berikut merupakan contoh implementasi fungsi tersebut:
 
 ```go
 func main() {
-    var max = 3
+    var maxNum = 3
     var numbers = []int{2, 3, 0, 4, 3, 2, 0, 4, 2, 0, 3}
-    var howMany, getNumbers = findMax(numbers, max)
+    var howMany, getNumbers = findMax(numbers, maxNum)
     var theNumbers = getNumbers()
 
     fmt.Println("numbers\t:", numbers)
-    fmt.Printf("find \t: %d\n\n", max)
+    fmt.Printf("find \t: %d\n\n", maxNum)
 
     fmt.Println("found \t:", howMany)    // 9
     fmt.Println("value \t:", theNumbers) // [2 3 0 3 2 0 2 0 3]

--- a/content/A-fungsi.md
+++ b/content/A-fungsi.md
@@ -76,8 +76,8 @@ func main() {
 	fmt.Println("random number:", randomValue)
 }
 
-func randomWithRange(min, max int) int {
-	var value = randomizer.Int()%(max-min+1) + min
+func randomWithRange(minNum, maxNum int) int {
+	var value = randomizer.Int()%(maxNum-minNum+1) + minNum
 	return value
 }
 ```
@@ -89,7 +89,7 @@ Fungsi `randomWithRange()` didesain untuk *generate* angka acak sesuai dengan ra
 Cara menentukan tipe data nilai balik fungsi adalah dengan menuliskan tipe data yang diinginkan setelah kurung parameter. Bisa dilihat pada kode di atas, bahwa `int` merupakan tipe data nilai balik fungsi `randomWithRange()`.
 
 ```go
-func randomWithRange(min, max int) int
+func randomWithRange(minNum, maxNum int) int
 ```
 
 Sedangkan cara untuk mengembalikan nilai itu sendiri adalah dengan menggunakan keyword `return` diikuti data yang dikembalikan. Pada contoh di atas, `return value` artinya nilai variabel `value` dijadikan nilai kembalian fungsi.
@@ -138,8 +138,8 @@ Khusus untuk fungsi yang tipe data parameternya sama, bisa ditulis dengan gaya y
 func nameOfFunc(paramA type, paramB type, paramC type) returnType
 func nameOfFunc(paramA, paramB, paramC type) returnType
 
-func randomWithRange(min int, max int) int
-func randomWithRange(min, max int) int
+func randomWithRange(minNum int, maxNum int) int
+func randomWithRange(minNum, maxNum int) int
 ```
 
 ## A.18.6. Penggunaan Keyword `return` Untuk Menghentikan Proses Dalam Fungsi


### PR DESCRIPTION
Tutorial ini menggunakan Go 1.22, sementara function `min` dan `max` introduced di versi 1.21 https://go.dev/ref/spec#Min_and_max, menggunakan `min` dan `max` untuk variable membuat ambigu dengan built-in functionnya.